### PR TITLE
Remove buffer restriction when writing temp file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This program is free software: you can redistribute it and/or modify it under th
 
 This issue is a known bug in `ansible-lint`, not in `flymake-ansible-lint`.
 
-It is `ansible-lint` that cuts off error messages:
+It is `ansible-lint` that truncates some error messages:
 ```
 $ ansible-lint -p test.yaml
 test.yaml:5: yaml[truthy]: Truthy value should be one of

--- a/flymake-ansible-lint.el
+++ b/flymake-ansible-lint.el
@@ -259,7 +259,9 @@ Returns the path of the newly created temporary file."
                    (file-exists-p temp-file-path)))
         (setq counter (1+ counter)))
       (unless (file-exists-p temp-file-path)
-        (write-region (point-min) (point-max) temp-file-path nil 'quiet)
+        (save-restriction
+          (widen)
+          (write-region (point-min) (point-max) temp-file-path nil 'quiet))
         temp-file-path))))
 
 (flymake-ansible-lint--quickdef-backend flymake-ansible-lint-backend


### PR DESCRIPTION
This prevents seeing bad diagnostic information which is only relevant when the narrowed region of the buffer is treated as a complete configuration file.

Fixes #2.